### PR TITLE
Ensure docs build script runs in docs directory

### DIFF
--- a/docs/build-docs.sh
+++ b/docs/build-docs.sh
@@ -3,6 +3,12 @@
 
 set -e
 
+# Ensure script runs from the docs directory
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ "$PWD" != "$SCRIPT_DIR" ]]; then
+    cd "$SCRIPT_DIR"
+fi
+
 echo "🌱 Building Seedling documentation..."
 
 # Check if uv is installed
@@ -27,4 +33,4 @@ echo ""
 echo "🌐 To serve locally, run:"
 echo "   cd docs && make serve"
 echo ""
-echo "📖 Or open build/html/index.html in your browser" 
+echo "📖 Or open build/html/index.html in your browser"


### PR DESCRIPTION
## Summary
- ensure docs build script runs from the `docs` directory

## Testing
- `./docs/build-docs.sh`

------
https://chatgpt.com/codex/tasks/task_e_689290510ed88326befc117c8ac05c5a